### PR TITLE
Make frontend API URL configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,13 @@ The backend will be available at `http://localhost:8000`
    npm install
    ```
 
-3. Run the development server:
+3. Set the environment variable used by the frontend to reach the backend API:
+   ```bash
+   # Example for a local backend
+   export NEXT_PUBLIC_API_URL=http://localhost:8000
+   ```
+
+4. Run the development server:
    ```bash
    npm run dev
    ```

--- a/frontend/src/app/components/LocationMap.tsx
+++ b/frontend/src/app/components/LocationMap.tsx
@@ -3,6 +3,8 @@
 import { useState, useEffect } from 'react';
 import axios from 'axios';
 
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+
 interface Location {
   id: number;
   name: string;
@@ -27,7 +29,7 @@ export default function LocationMap() {
 
   const fetchLocations = async () => {
     try {
-      const response = await axios.get('http://localhost:8000/gis/locations');
+      const response = await axios.get(`${API_URL}/gis/locations`);
       setLocations(response.data);
     } catch (error) {
       console.error('Error fetching locations:', error);
@@ -37,7 +39,7 @@ export default function LocationMap() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      await axios.post('http://localhost:8000/gis/locations', newLocation);
+      await axios.post(`${API_URL}/gis/locations`, newLocation);
       setNewLocation({ name: '', latitude: 0, longitude: 0, description: '' });
       fetchLocations();
     } catch (error) {
@@ -47,7 +49,7 @@ export default function LocationMap() {
 
   const calculateDistance = async (from: Location, to: Location) => {
     try {
-      const response = await axios.post('http://localhost:8000/gis/distance', {
+      const response = await axios.post(`${API_URL}/gis/distance`, {
         from_lat: from.latitude,
         from_lon: from.longitude,
         to_lat: to.latitude,

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -4,13 +4,15 @@ import { useEffect, useState } from 'react';
 import axios from 'axios';
 import LocationMap from './components/LocationMap';
 
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+
 export default function Home() {
   const [apiStatus, setApiStatus] = useState<string>('loading');
 
   useEffect(() => {
     const checkApiHealth = async () => {
       try {
-        const response = await axios.get('http://localhost:8000/api/health');
+        const response = await axios.get(`${API_URL}/api/health`);
         setApiStatus(response.data.status);
       } catch (error) {
         setApiStatus('error');


### PR DESCRIPTION
## Summary
- add `NEXT_PUBLIC_API_URL` usage in `page.tsx` and `LocationMap.tsx`
- document the environment variable in setup instructions

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6846e05a8188832a87f51fc3ed740fe5