### PR TITLE
Add datetime import to GIS router

### DIFF
--- a/backend/app/routers/gis.py
+++ b/backend/app/routers/gis.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, HTTPException
 from geopy.distance import geodesic
 from typing import List
+from datetime import datetime
 from ..models import Location, LocationCreate, DistanceRequest, DistanceResponse, NearbyRequest
 
 router = APIRouter(prefix="/gis", tags=["gis"])


### PR DESCRIPTION
## Summary
- add missing `datetime` import in the GIS router

## Testing
- `python -m py_compile backend/app/routers/gis.py`


------
https://chatgpt.com/codex/tasks/task_e_6846e03cc0dc832ab95f2fc88b929f66