### PR TITLE
Add simple admin GUI

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from .routers import gis
+from .routers import gis, gui
 
 app = FastAPI(
     title="GIS API",
@@ -19,6 +19,7 @@ app.add_middleware(
 
 # Include routers
 app.include_router(gis.router)
+app.include_router(gui.router)
 
 @app.get("/")
 async def root():

--- a/backend/app/routers/gui.py
+++ b/backend/app/routers/gui.py
@@ -1,0 +1,39 @@
+from fastapi import APIRouter, Request, Form
+from fastapi.templating import Jinja2Templates
+from fastapi.responses import RedirectResponse
+from typing import Optional
+from datetime import datetime
+
+from .gis import locations
+from ..models import Location
+
+router = APIRouter()
+
+templates = Jinja2Templates(directory="app/templates")
+
+@router.get("/admin")
+async def admin_dashboard(request: Request):
+    """Display admin interface for managing locations"""
+    return templates.TemplateResponse("admin.html", {
+        "request": request,
+        "locations": locations
+    })
+
+@router.post("/admin/locations")
+async def add_location(
+    name: str = Form(...),
+    latitude: float = Form(...),
+    longitude: float = Form(...),
+    description: Optional[str] = Form(None)
+):
+    """Add a new location via the admin form"""
+    new_location = Location(
+        id=len(locations) + 1,
+        name=name,
+        latitude=latitude,
+        longitude=longitude,
+        description=description,
+        created_at=datetime.now()
+    )
+    locations.append(new_location)
+    return RedirectResponse(url="/admin", status_code=303)

--- a/backend/app/templates/admin.html
+++ b/backend/app/templates/admin.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Location Admin</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 2em; }
+        form { margin-bottom: 2em; }
+        table { border-collapse: collapse; width: 100%; }
+        th, td { border: 1px solid #ddd; padding: 8px; }
+        th { background-color: #f2f2f2; }
+    </style>
+</head>
+<body>
+    <h1>Location Admin</h1>
+    <form action="/admin/locations" method="post">
+        <input name="name" placeholder="Name" required>
+        <input name="latitude" placeholder="Latitude" type="number" step="any" required>
+        <input name="longitude" placeholder="Longitude" type="number" step="any" required>
+        <input name="description" placeholder="Description">
+        <button type="submit">Add</button>
+    </form>
+    <table>
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>Name</th>
+                <th>Latitude</th>
+                <th>Longitude</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for loc in locations %}
+            <tr>
+                <td>{{ loc.id }}</td>
+                <td>{{ loc.name }}</td>
+                <td>{{ loc.latitude }}</td>
+                <td>{{ loc.longitude }}</td>
+                <td>{{ loc.description or '' }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</body>
+</html>

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,4 +8,5 @@ python-jose[cryptography]==3.3.0
 passlib[bcrypt]==1.7.4
 python-multipart==0.0.9
 geopy==2.4.1
-shapely==2.0.2 
+shapely==2.0.2
+jinja2==3.1.3


### PR DESCRIPTION
## Summary
- expose a basic admin page from FastAPI
- include a minimal HTML template for managing locations
- wire up the new router and add jinja2 to requirements

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846e632b150832aa2cff72e493af192